### PR TITLE
Fix link to slides for A Few Useful Things To Know About Machine Learning

### DIFF
--- a/useful-things-to-know-about-ml/README.md
+++ b/useful-things-to-know-about-ml/README.md
@@ -3,4 +3,4 @@
 - PWL @ Seattle [#23](https://www.meetup.com/Papers-We-Love-Seattle/events/233068249/)
 - Presented by [Tristan Penman](http://tristanpenman.com)
 - Read [A Few Useful Things To Know About Machine Learning](http://homes.cs.washington.edu/~pedrod/papers/cacm12.pdf)
-- View [the slides](http://www.slideshare.net/tristanpenman/pwl-seattle-a-few-useful-things-to-know-about-machine-learning)
+- View [the slides](http://www.slideshare.net/tristanpenman/pwl-seattle-a-few-useful-things-to-know-about-machine-learning/)


### PR DESCRIPTION
The previous link was missing a trailing slash, which may cause the link to be broken on some (or even all) browsers.
